### PR TITLE
get all categories added

### DIFF
--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -11,6 +11,7 @@ import MyPosts from "./MyPosts";
 import ConfirmDelete from "./ConfirmDelete";
 import { PostDetails } from "./PostDetails";
 import {TagList} from "../components/tag/TagList"
+import { CategoryList } from "../components/Category/CategoryList"
 
 export default function ApplicationViews() {
   // import the isLoggedIn state variable from the UserProfileContext
@@ -59,6 +60,10 @@ export default function ApplicationViews() {
 
         <Route path="/tags" exact>
           {isLoggedIn ? <TagList /> : <Redirect to="/login" />}
+        </Route>
+
+        <Route path="/categories" exact>
+          {isLoggedIn ? <CategoryList /> : <Redirect to="/login" />}
         </Route>
 
         <Route exact path="/post/delete/:postId">

--- a/Tabloid/client/src/components/Category/Category.js
+++ b/Tabloid/client/src/components/Category/Category.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { Card, CardBody } from "reactstrap";
+
+export const Category = ({ category }) => {
+    console.log(1)
+  return (
+    <Card className="m-4">
+      <CardBody>
+        <strong>{category.name}</strong>
+      </CardBody>
+    </Card>
+  );
+}

--- a/Tabloid/client/src/components/Category/CategoryList.js
+++ b/Tabloid/client/src/components/Category/CategoryList.js
@@ -1,0 +1,31 @@
+import React, { useContext, useEffect } from "react";
+import { useHistory } from "react-router-dom";
+import {Category } from "./Category";
+import { CategoryContext } from "../../providers/CategoryProvider";
+import Button from "reactstrap/lib/Button";
+
+export const CategoryList=() => {
+  const history = useHistory();
+  const { categories, getAllCategories } = useContext(CategoryContext);
+
+  useEffect(() => {
+    getAllCategories();
+  }, []);
+
+
+  return (
+    <div className="container">
+      <div className="row justify-content-center">
+        <div className="cards-column">
+            {// sorting categories alphabetically
+            categories.sort((a, b) => a.name.localeCompare(b.name))
+            //map through all categories in database 
+            .map((category) => (
+            <Category key={category.id} category={category} />
+            ))}
+        </div>
+      </div>
+    </div>
+
+  );
+}

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -49,6 +49,9 @@ export default function Header() {
                 <NavItem>
                   <NavLink tag={RRNavLink} to="/tags">Tag Management</NavLink>
                 </NavItem>
+                <NavItem>
+                  <NavLink tag={RRNavLink} to="/categories">Category Management</NavLink>
+                </NavItem>
                 
               </>
             }


### PR DESCRIPTION
# Description
As an admin I would like to see all the available categories so that I can choose to edit or delete one, or see that I should add a new one.
Given an admin is in the app
When they select the Category Management link in the menu
Then they should be directed to a page that lists all the Category names ordered alphabetically

NOTE: For the time being it is acceptable to treat all users as admin users. There is a future story about enforcing user permissions.

Added the capability of listing all categories in alphabetical order

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions
-Run app (client and server)
-Log in
-Select "category management" from menu
-Confirm that you see a list of all categories in alphabetical order


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x ] I have added test instructions that prove my fix is effective or that my feature works
