### PR TITLE
Cl create category

### DIFF
--- a/Tabloid/Controllers/CategoryControllercs.cs
+++ b/Tabloid/Controllers/CategoryControllercs.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Tabloid.Models;
 using Tabloid.Repositories;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
@@ -36,10 +37,12 @@ namespace Tabloid.Controllers
             return "value";
         }
 
-        // POST api/<CategoryControllercs>
+        // POST api/<CategoryController>
         [HttpPost]
-        public void Post([FromBody] string value)
+        public IActionResult Category(Category category)
         {
+            _categoryRepository.Add(category);
+            return Ok(category);
         }
 
         // PUT api/<CategoryControllercs>/5

--- a/Tabloid/Repositories/CategoryRepository.cs
+++ b/Tabloid/Repositories/CategoryRepository.cs
@@ -38,6 +38,29 @@ namespace Tabloid.Repositories
             }
         }
 
+        public void Add(Category category)
+        {
+            
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        INSERT INTO Category (
+                            Name )
+                        OUTPUT INSERTED.ID
+                        VALUES (
+                            @Name
+                                )";
+                    cmd.Parameters.AddWithValue("@Name", category.Name);
+                    
+
+                    category.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+
         private Category NewCategoryFromReader(SqlDataReader reader)
         {
             return new Category()

--- a/Tabloid/Repositories/ICategoryRepository.cs
+++ b/Tabloid/Repositories/ICategoryRepository.cs
@@ -9,5 +9,6 @@ namespace Tabloid.Repositories
     public interface ICategoryRepository
     {
         List<Category> GetAll();
+        void Add(Category category);
     }
 }

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -11,11 +11,9 @@ import MyPosts from "./MyPosts";
 import ConfirmDelete from "./ConfirmDelete";
 import { PostDetails } from "./PostDetails";
 import {TagList} from "../components/tag/TagList"
-<<<<<<< HEAD
 import {TagForm} from "../components/tag/TagForm"
-=======
 import { CategoryList } from "../components/Category/CategoryList"
->>>>>>> main
+import { CategoryForm } from "../components/Category/CategoryForm"
 
 export default function ApplicationViews() {
   // import the isLoggedIn state variable from the UserProfileContext
@@ -61,6 +59,11 @@ export default function ApplicationViews() {
         <Route path="/postdetails/:postId(\d+)">
           {isLoggedIn ? <PostDetails/> : <Redirect to="/login" />}
         </Route>
+        
+        <Route path="/tags" exact>
+          {isLoggedIn ? <TagList /> : <Redirect to="/login" />}
+        </Route>
+
 
         <Route path="/tags/tagForm" exact>
           {isLoggedIn ? <TagForm /> : <Redirect to="/login" />}
@@ -68,6 +71,10 @@ export default function ApplicationViews() {
 
         <Route path="/categories" exact>
           {isLoggedIn ? <CategoryList /> : <Redirect to="/login" />}
+        </Route>
+
+        <Route path="/categories/categoryForm" exact>
+          {isLoggedIn ? <CategoryForm /> : <Redirect to="/login" />}
         </Route>
 
         <Route exact path="/post/delete/:postId">

--- a/Tabloid/client/src/components/Category/Category.js
+++ b/Tabloid/client/src/components/Category/Category.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Card, CardBody } from "reactstrap";
+import Button from "reactstrap/lib/Button";
 
 export const Category = ({ category }) => {
     console.log(1)

--- a/Tabloid/client/src/components/Category/CategoryForm.js
+++ b/Tabloid/client/src/components/Category/CategoryForm.js
@@ -1,0 +1,42 @@
+import React, { useState, useContext } from "react";
+import { useHistory } from "react-router-dom";
+import { CategoryContext } from "../../providers/CategoryProvider";
+
+export const CategoryForm = () => {
+  const history = useHistory();
+  //exposing the addCategory function from the CategoryProdiver
+  const { addCategory } = useContext(CategoryContext);
+  // setting categroryText to an empty state so we can add in the new category information
+  const [categoryInput, setCategoryInput] = useState();
+
+  const handleControlledInputChange = (event) => {
+      let newCategory = { ...categoryInput}
+      newCategory[event.target.id] = event.target.value 
+      setCategoryInput(newCategory)
+  }
+
+  const handleClickAddCategory = (event) => {
+      event.preventDefault()
+      addCategory({
+          name: categoryInput.name
+    })
+    .then(() => history.push("/categories"))
+  }
+  
+  return (
+    <form className="categoryForm">
+    <h2 className="categoryForm__title">Add Category</h2>
+    <fieldset>
+        <div className="form-group">
+            <label htmlFor="title">Category Name:</label>
+            <input type="text" id="name" onChange={handleControlledInputChange} required autoFocus className="form-control" placeholder="" value={categoryInput?.name} />
+        </div>
+    </fieldset>
+    
+    <button className="btn btn-primary"
+        onClick={handleClickAddCategory}>
+        Save Category
+        </button>
+    </form>
+  );
+}

--- a/Tabloid/client/src/components/Category/CategoryList.js
+++ b/Tabloid/client/src/components/Category/CategoryList.js
@@ -15,7 +15,8 @@ export const CategoryList=() => {
 
   return (
     <div className="container">
-      <button>Cretae New Category</button>
+
+      <div><Button onClick={() => history.push("/categories/categoryForm")}>Create Category</Button></div>
       <div className="row justify-content-center">
         
         <div className="cards-column">

--- a/Tabloid/client/src/components/Category/CategoryList.js
+++ b/Tabloid/client/src/components/Category/CategoryList.js
@@ -15,7 +15,9 @@ export const CategoryList=() => {
 
   return (
     <div className="container">
+      <button>Cretae New Category</button>
       <div className="row justify-content-center">
+        
         <div className="cards-column">
             {// sorting categories alphabetically
             categories.sort((a, b) => a.name.localeCompare(b.name))

--- a/Tabloid/client/src/providers/CategoryProvider.js
+++ b/Tabloid/client/src/providers/CategoryProvider.js
@@ -20,10 +20,28 @@ export const CategoryProvider = (props) => {
       .then(resp => resp.json())
       .then(setCategories);
   };
+
+  const addCategory = (category) => {
+    return getToken().then((token) =>
+        fetch(apiUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(category)
+    }).then(resp => {
+      // debugger
+      if (resp.ok) {
+        return resp.json();
+      }
+      throw new Error("Unauthorized");
+    }));
+  };
   
     
   return (
-    <CategoryContext.Provider value={{ categories, getAllCategories }}>
+    <CategoryContext.Provider value={{ categories, getAllCategories, addCategory }}>
       {props.children}
     </CategoryContext.Provider>
   );


### PR DESCRIPTION
# Description
As an admin I would like to be able to create a new category so that I can give authors the ability to better classify their posts.

Given an admin is on the Category list page
When they select the Create Category button
Then they should be directed to a form in which they can enter a new category name

Given an admin has entered a Category name
When they click the Save button
Then a new category should be saved to the database
And the admin should be directed to the Category list page

NOTE: For the time being it is acceptable to treat all users as admin users. There is a future story about enforcing user permissions.

Create category capability added

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
 
# Testing Instructions
Run app (client and server)
Log in as valid user
Go to "Category Management" in menu
Click "Create Category" button
Create a category and press save
Confirm newly created category exists

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
