### PR TITLE
Pp edit tag

### DIFF
--- a/Tabloid/Controllers/TagController.cs
+++ b/Tabloid/Controllers/TagController.cs
@@ -30,10 +30,15 @@ namespace Tabloid.Controllers
         }
 
         // GET api/<TagController>/5
-        [HttpGet("{id}")]
-        public string Get(int id)
+        [HttpGet("{tagId}")]
+        public IActionResult Get(int tagId)
         {
-            return "value";
+            var tag = _tagRepository.GetById(tagId);
+            if (tag == null)
+            {
+                return NotFound();
+            }
+                return Ok(tag);
         }
 
         // POST api/<TagController>

--- a/Tabloid/Controllers/TagController.cs
+++ b/Tabloid/Controllers/TagController.cs
@@ -46,8 +46,10 @@ namespace Tabloid.Controllers
 
         // PUT api/<TagController>/5
         [HttpPut("{id}")]
-        public void Put(int id, [FromBody] string value)
+        public IActionResult Put(Tag tag)
         {
+            _tagRepository.Edit(tag);
+            return NoContent();
         }
 
         // DELETE api/<TagController>/5

--- a/Tabloid/Repositories/ITagRepository.cs
+++ b/Tabloid/Repositories/ITagRepository.cs
@@ -10,5 +10,6 @@ namespace Tabloid.Repositories
     {
         List<Tag> GetAllTags();
         void Add(Tag tag);
+        void Edit(Tag tag);
     }
 }

--- a/Tabloid/Repositories/ITagRepository.cs
+++ b/Tabloid/Repositories/ITagRepository.cs
@@ -12,5 +12,6 @@ namespace Tabloid.Repositories
         void Add(Tag tag);
         void Edit(Tag tag);
         void Delete(int id);
+        Tag GetById(int id);
     }
 }

--- a/Tabloid/Repositories/TagRepository.cs
+++ b/Tabloid/Repositories/TagRepository.cs
@@ -98,5 +98,38 @@ namespace Tabloid.Repositories
                 }
             }
         }
+
+        public Tag GetById(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                SELECT Id, Name
+                From Tag
+                WHERE Id = @id";
+
+                    DbUtils.AddParameter(cmd, "@id", id);
+
+                    var reader = cmd.ExecuteReader();
+
+                    Tag tag = null;
+                    if (reader.Read())
+                    {
+                        tag = new Tag()
+                        {
+                            Id = DbUtils.GetInt(reader, "Id"),
+                            Name = DbUtils.GetString(reader, "Name"),
+                        };
+                    }
+                    reader.Close();
+
+                    return tag;
+                }
+            }
+        }
+
     }
 };

--- a/Tabloid/Repositories/TagRepository.cs
+++ b/Tabloid/Repositories/TagRepository.cs
@@ -57,5 +57,24 @@ namespace Tabloid.Repositories
                 }
             }
         }
+
+        public void Edit (Tag tag)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"UPDATE Tag
+                                        SET [Name] = @name
+                                        WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@id", tag.Id);
+                    cmd.Parameters.AddWithValue("@name", tag.Name);
+                    
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
     }
 };

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -77,7 +77,7 @@ export default function ApplicationViews() {
           {isLoggedIn ? <TagForm /> : <Redirect to="/login" />}
         </Route>
 
-        <Route exact path="/tags/edit/:tagId(\d+)">
+        <Route exact path="/tag/edit/:tagId(\d+)">
           {isLoggedIn ? <TagForm /> : <Redirect to="/login" />}
         </Route>
 

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -69,6 +69,10 @@ export default function ApplicationViews() {
           {isLoggedIn ? <TagForm /> : <Redirect to="/login" />}
         </Route>
 
+        <Route exact path="/tags/edit/:tagId(\d+)">
+          {isLoggedIn ? <TagForm /> : <Redirect to="/login" />}
+        </Route>
+
         <Route exact path="/categories">
           {isLoggedIn ? <CategoryList /> : <Redirect to="/login" />}
         </Route>

--- a/Tabloid/client/src/components/tag/Tag.js
+++ b/Tabloid/client/src/components/tag/Tag.js
@@ -1,12 +1,18 @@
 import React from "react";
-import { Card, CardBody } from "reactstrap";
+import {useHistory} from "react-router-dom";
+import { Card, CardBody, Button } from "reactstrap";
 
 export const Tag = ({ tag }) => {
+  const history = useHistory();
     // console.log(tag)
   return (
     <Card className="m-4">
       <CardBody>
         <strong>{tag.name}</strong>
+        <div className="button-container"> 
+        <Button className="button btn btn-sm" onClick={() => {history.push(`/tag/edit/${tag.id}`)}}>Edit</Button> 
+        </div>
+             
       </CardBody>
     </Card>
   );

--- a/Tabloid/client/src/components/tag/TagForm.js
+++ b/Tabloid/client/src/components/tag/TagForm.js
@@ -1,13 +1,28 @@
-import React, { useState, useContext } from "react";
-import { useHistory } from "react-router-dom";
+import React, { useState, useContext, useEffect } from "react";
+import { useHistory, useParams } from "react-router-dom";
 import { TagContext } from "../../providers/TagProvider";
 
 export const TagForm = () => {
-  const history = useHistory();
   //exposing the addTag function from the TagProdiver
-  const { addTag } = useContext(TagContext);
-  // setting tagText to an empty state so we can add in the new tag information
-  const [tagInput, setTagInput] = useState();
+  const { addTag, editTag, getTagById } = useContext(TagContext);
+  // setting tagInput to an empty state so we can add in the new tag information
+  const [tagInput, setTagInput] = useState({});
+  const {tagId} = useParams();
+  const history = useHistory();
+  // wait for data before button is active
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if(tagId){
+      getTagById(tagId)
+      .then(tag => {
+        setTagInput(tag)
+        setIsLoading(false)
+      })
+    } else {
+      setIsLoading(false)
+    }
+  }, []);
 
   const handleControlledInputChange = (event) => {
       let newTag = { ...tagInput}
@@ -16,7 +31,15 @@ export const TagForm = () => {
   }
 
   const handleClickAddTag = (event) => {
-      event.preventDefault()
+      event.preventDefault();
+      setIsLoading(true);
+      if(tagId){
+        editTag({
+          Id: parseInt(tagId),
+          Name: tagInput.name
+        })
+        .then(() => history.push(`/tags`))
+      }
       addTag({
           name: tagInput.name
     })

--- a/Tabloid/client/src/components/tag/TagForm.js
+++ b/Tabloid/client/src/components/tag/TagForm.js
@@ -4,7 +4,6 @@ import { TagContext } from "../../providers/TagProvider";
 
 export const TagForm = () => {
   //exposing the addTag function from the TagProdiver
-<<<<<<< HEAD
   const { addTag, editTag, getTagById } = useContext(TagContext);
   // setting tagInput to an empty state so we can add in the new tag information
   const [tagInput, setTagInput] = useState({});
@@ -24,11 +23,6 @@ export const TagForm = () => {
       setIsLoading(false)
     }
   }, []);
-=======
-  const { addTag } = useContext(TagContext);
-  // setting tagInput to an empty state so we can add in the new tag information
-  const [tagInput, setTagInput] = useState({});
->>>>>>> main
 
   //update state when a field changes; the return will re-render and display based on the values in state
   const handleControlledInputChange = (event) => {
@@ -43,19 +37,18 @@ export const TagForm = () => {
   const handleClickAddTag = (event) => {
       event.preventDefault();
       setIsLoading(true);
-      //debugger
       if(tagId){
-        //debugger
         editTag({
           Id: parseInt(tagId),
           Name: tagInput.name
         })
         .then(() => history.push(`/tags`))
-      }
-      addTag({
+      } else {
+        addTag({
           name: tagInput.name
     })
     .then(() => history.push("/tags"))
+    }
   }
   
   return (
@@ -64,14 +57,16 @@ export const TagForm = () => {
     <fieldset>
         <div className="form-group">
             <label htmlFor="title">Tag Name:</label>
-            <input type="text" id="name" onChange={handleControlledInputChange} required autoFocus className="form-control" placeholder="" value={tagInput?.name} />
+            <input type="text" id="name" onChange={handleControlledInputChange} required autoFocus className="form-control" placeholder="" value={tagInput.name} />
         </div>
     </fieldset>
     
     <button className="btn btn-primary"
-        onClick={handleClickAddTag}>
-        Save Tag
+        onClick={handleClickAddTag}
+        disable={isLoading.toString()}>
+        {tagId ? <>Save Tag</> : <>Add Tag</>}
         </button>
+        <button className="button btn btn-sm btn-secondary" onClick={() => {history.push("/tags")}}>Cancel</button>
     </form>
   );
 }

--- a/Tabloid/client/src/components/tag/TagForm.js
+++ b/Tabloid/client/src/components/tag/TagForm.js
@@ -33,7 +33,9 @@ export const TagForm = () => {
   const handleClickAddTag = (event) => {
       event.preventDefault();
       setIsLoading(true);
+      //debugger
       if(tagId){
+        //debugger
         editTag({
           Id: parseInt(tagId),
           Name: tagInput.name

--- a/Tabloid/client/src/providers/TagProvider.js
+++ b/Tabloid/client/src/providers/TagProvider.js
@@ -46,6 +46,7 @@ export const TagProvider = (props) => {
     }
 
     const getTagById = (tagId) => {
+      //debugger
       return getToken().then((token) =>
           fetch(`${apiUrl}/${tagId}`, {
               method: "GET",
@@ -59,10 +60,10 @@ export const TagProvider = (props) => {
   // Provider method to edit a tag by sending a PUT request based on a Tag Object
   // to the Web API with a firebase Token for authentication.
   const editTag = (tag) => {
-    // debugger
+    debugger
     return getToken().then((token) => {
-        // debugger
-        fetch(apiUrl, {
+        debugger
+        fetch(`${apiUrl}/${tag.Id}`, {
             method: "PUT",
             headers: {
                 Authorization: `Bearer ${token}`,

--- a/Tabloid/client/src/providers/TagProvider.js
+++ b/Tabloid/client/src/providers/TagProvider.js
@@ -33,9 +33,37 @@ export const TagProvider = (props) => {
               body: JSON.stringify(tag)
       }));
     };
+
+    const getTagById = (tagId) => {
+      return getToken().then((token) =>
+          fetch(`${apiUrl}/${tagId}`, {
+              method: "GET",
+              headers: {
+                  Authorization: `Bearer ${token}`
+              }
+          }))
+          .then(resp => resp.json())    
+    }
+
+  // Provider method to edit a tag by sending a PUT request based on a Tag Object
+  // to the Web API with a firebase Token for authentication.
+  const editTag = (tag) => {
+    // debugger
+    return getToken().then((token) => {
+        // debugger
+        fetch(apiUrl, {
+            method: "PUT",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(tag)
+    })});
+  };
+
   
   return (
-    <TagContext.Provider value={{tags, getAllTags, addTag}}>
+    <TagContext.Provider value={{tags, getAllTags, addTag, getTagById, editTag}}>
       {props.children}
     </TagContext.Provider>
   );


### PR DESCRIPTION
# Description
As an admin I would like the ability to edit a tag allowing the name to be rephrased to something more appropriate if needed. If an Admin is logged in they should be afforded the option on each tag to edit the name and save the new one to the database. The Admin should also be given the option to cancel that edit if they change their mind during the process.
​

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions
1.Pull down and checkout my branch pp-edit-tags
2.Start the application in VS and run the program
3.When the application loads you will also need to open the client-side portion of the project and run npm start from the terminal
4.use foo@bar.com and password: password to log in to the application
5.Once logged in navigate to the TAGS MANAGEMENT tab and click the link shown
6.At this point an Admin should see a button allowing them to edit a tag of their choosing
7.When the edit button is clicked the Admin should be routed to a form allowing them to make an edit to the name and save that name
8.If they wish to cancel and not change the name cancel should be clicked and the Admin will be rerouted back to the list of all tags
9.If the tag has been edited and saved the Admin should be rerouted back to the list of all tags showing the newly edited tag along with all other tags confirming the test

# Checklist:
- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings or errors
- [x ] I have added test instructions that prove my fix is effective or that my feature works
